### PR TITLE
[SA-20443] Fix delegate method being called

### DIFF
--- a/Sources/RangeSeekSlider/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider/RangeSeekSlider.swift
@@ -463,8 +463,8 @@ import UIKit
 
         updateColors()
 
-        if handleTracking != .none {
-            delegate?.rangeSeekSlider(self, didChange: selectedMinValue, maxValue: selectedMaxValue)
+        if let delegate, handleTracking != .none {
+            delegate.rangeSeekSlider(self, didChange: selectedMinValue, maxValue: selectedMaxValue)
         }
 
         layoutContent()

--- a/Sources/RangeSeekSlider/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider/RangeSeekSlider.swift
@@ -463,7 +463,9 @@ import UIKit
 
         updateColors()
 
-        delegate?.rangeSeekSlider(self, didChange: selectedMinValue, maxValue: selectedMaxValue)
+        if handleTracking != .none {
+            delegate?.rangeSeekSlider(self, didChange: selectedMinValue, maxValue: selectedMaxValue)
+        }
 
         layoutContent()
     }


### PR DESCRIPTION
On iOS, when clearing the filters, the delegate method was being called on every slider which caused some issues. By re-adding this check before calling the method, the clearing of the filters works as expected again.